### PR TITLE
Add ping command (admins/mods only)

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -35,3 +35,31 @@ exports.choose = function(arr) {
     let rand = Math.floor(Math.random() * arr.length);
     return arr[rand];
 };
+
+exports.memberHasPrivilege = function(checkAdmin, checkModerator, server, member) {
+    if (!checkAdmin && !checkModerator) return true;
+
+    let admin_role = null;
+    let moderator_role = null;
+
+    for (const key in server.roles) {
+        if (server.roles.hasOwnProperty(key)) {
+            const role = server.roles[key];
+            if (role.name == 'Admins') {
+                admin_role = role;
+                break;
+            }
+
+            if (role.name == 'Moderators') {
+                moderator_role = role;
+                break;
+            }
+        }
+
+        if (!admin_role || admin_role.name != 'Admins') return false;
+        if (!moderator_role || moderator_role.name != 'Moderators') return false;
+
+        if (checkAdmin && member.roles.indexOf(admin_role.id) >= 0) return true;
+        if (checkModerator && member.roles.indexOf(moderator_role.id) >= 0) return true;
+        return false;
+};

--- a/twhl.js
+++ b/twhl.js
@@ -128,19 +128,8 @@ bot.on('message', function(user, userID, channelID, message, evt) {
                 let server = bot.servers[channel.guild_id];
                 let member = server.members[userID];
 
-                let admin_role = null;
-                for (const key in server.roles) {
-                    if (server.roles.hasOwnProperty(key)) {
-                        const role = server.roles[key];
-                        if (role.name == 'Admins') {
-                            admin_role = role;
-                            break;
-                        }
-                    }
-                }
-                if (!admin_role || admin_role.name != 'Admins') break;
-                if (member.roles.indexOf(admin_role.id) < 0) break;
-                
+                if (!lib.memberHasPrivilege(true, false, server, member)) break;
+
                 bot.sendMessage({
                     to: channelID,
                     message: 'Updating...'

--- a/twhl.js
+++ b/twhl.js
@@ -139,6 +139,21 @@ bot.on('message', function(user, userID, channelID, message, evt) {
                     child_process.execSync('pm2 restart twhl.js');
                 });
                 break;
+            // Ping
+            case 'ping':
+                if (channelID !== '513507834885963812') break;
+
+                let channel = bot.channels[channelID];
+                let server = bot.servers[channel.guild_id];
+                let member = server.members[userID];
+
+                if (!lib.memberHasPrivilege(true, true, server, member)) break;
+
+                bot.sendMessage({
+                    to: channelID,
+                    message: 'Pong!'
+                });
+                break;
             // Just add any case commands if you want to..
         }
     } else {


### PR DESCRIPTION
This PR add a ping command for admins and moderators to check if the bot is still alive.

To prevent spamming, the command only works for admins and moderators on a specific private channel.