### PR TITLE
Replace mention by text for leaving message

### DIFF
--- a/twhl.js
+++ b/twhl.js
@@ -79,5 +79,5 @@ bot.on('guildMemberAdd', member => {
 bot.on('guildMemberRemove', member => {
     member.guild.channels.cache
         .find(ch => ch.name === 'shoutbox-live')
-        .send(`${member} just left us... :cry:`);
+        .send(`${member.displayName} (*${member.user.username}#${member.user.discriminator}*) just left us... :cry:`);
 });


### PR DESCRIPTION
This fixes the "weird member mention" (`@<Discord user ID>`) problem on mobile and on desktop since the switch to DiscordJS by replacing it to `<Nickname on TWHL Discord> (*<Discord username>#<Discord discriminator>*)`.