### PR TITLE
Fix crash due to null MessageEmbedProvider

### DIFF
--- a/events/log-messages.js
+++ b/events/log-messages.js
@@ -31,7 +31,12 @@ module.exports = {
             if (message.member.user.bot) return;
 
             const embeds = message.embeds.map(e => {
-                const values = [e.type + ' - ' + e.provider.name, e.title, e.url];
+                let values;
+                if (e.provider != null) {
+                    values = [e.type + ' - ' + e.provider.name, e.title, e.url];
+                } else {
+                    values = [e.type, e.title, e.url];
+                }
                 return { name: 'Embed', value: values.filter(x => x).join('\n') };
             });
             const attachInfo = message.attachments.map(a => {
@@ -61,7 +66,7 @@ module.exports = {
         bot.on('messageUpdate', (oldMessage, message) => {
             if (!logChannel) return;
             if (message.member.user.bot) return;
-            
+
             const alert = new Discord.MessageEmbed()
                 .setColor('#FFBA1C')
                 .setTitle('Message updated')


### PR DESCRIPTION
This PR fixes a bot crash on message logging due to a `null` value for the `provider` (`MessageEmbedProvider`) field from the embed.